### PR TITLE
Add Boss Check to Raidwide Checking

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -7169,7 +7169,7 @@ public enum CustomComboPreset
     WHM_AoEHeals_DivineCaress = 19207,
 
     [ParentCombo(WHM_AoEHeals)]
-    [CustomComboInfo("Liturgy of the Bell Option", "Adds Liturgy of the Bell (Lilybell) placement to the rotation.\nFocuses on raidwide damage detection for optimal placement timing.", WHM.JobID)]
+    [CustomComboInfo("Liturgy of the Bell Option", "Adds Liturgy of the Bell (Lilybell) placement to the rotation.", WHM.JobID)]
     [Retargeted]
     WHM_AoEHeals_LiturgyOfTheBell = 19206,
 

--- a/WrathCombo/Combos/PvE/WHM/WHM.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM.cs
@@ -347,8 +347,10 @@ internal partial class WHM : Healer
                 ActionReady(LiturgyOfTheBell) &&
                 !HasStatusEffect(Buffs.LiturgyOfTheBell) &&
                 !JustUsed(LiturgyOfTheBell) &&
-                (!Config.WHM_AoEHeals_LiturgyRaidwideOnly || RaidWideCasting()) &&
-                ContentCheck.IsInConfiguredContent(Config.WHM_AoEHeals_LiturgyDifficulty, Config.WHM_AoEHeals_LiturgyDifficultyListSet))
+                BellRaidwideCheckPassed &&
+                ContentCheck.IsInConfiguredContent(
+                    Config.WHM_AoEHeals_LiturgyDifficulty,
+                    Config.WHM_AoEHeals_LiturgyDifficultyListSet))
                 return LiturgyOfTheBell.Retarget(Medica1, bellTarget);
 
             var asylumTarget =

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -1,6 +1,8 @@
 ﻿#region
 
+using System.Numerics;
 using Dalamud.Interface.Colors;
+using ECommons.ImGuiMethods;
 using ImGuiNET;
 using WrathCombo.CustomComboNS.Functions;
 using WrathCombo.Data;
@@ -227,6 +229,24 @@ internal partial class WHM
                     DrawAdditionalBoolChoice(WHM_AoEHeals_LiturgyRaidwideOnly,
                         "Only use when a Raidwide is casting",
                         "Will not use Liturgy of the Bell in the rotation unless we detect a Raidwide is casting.");
+
+                    if (WHM_AoEHeals_LiturgyRaidwideOnly)
+                    {
+                        ImGuiEx.Spacing(new Vector2(40f, 0f));
+                        ImGui.Text("Against what enemies should we check for Raidwides:");
+                        DrawRadioButton(
+                            WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "All Enemies",
+                            "Will check for a Raidwide before using Bell at all times, on all enemies.",
+                            outputValue: (int) BossRequirement.Off, itemWidth: 125f,
+                            descriptionAsTooltip: true);
+                        DrawRadioButton(
+                            WHM_AoEHeals_LiturgyRaidwideOnlyBoss, "Only Bosses",
+                            "Will try to only check for Raidwide when fighting bosses.\n" +
+                            "(will use on cooldown versus regular enemies)\n" +
+                            "(Note: don't rely on this 100%, square sometimes marks enemies inconsistently)",
+                            outputValue: (int) BossRequirement.On, itemWidth: 125f,
+                            descriptionAsTooltip: true);
+                    }
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_Asylum:
@@ -273,6 +293,15 @@ internal partial class WHM
 
         private const string mouseoverCheckingDescription =
             "Party UI Mouseover Checking";
+
+        /// <summary>
+        ///     Whether abilities should be restricted to bosses or not.
+        /// </summary>
+        internal enum BossRequirement
+        {
+            Off = 1,
+            On = 2,
+        }
 
         /// <summary>
         ///     Enemy type restriction for HP threshold checks.
@@ -636,21 +665,40 @@ internal partial class WHM
             new("WHM_AoEHeals_LiturgyRaidwideOnly");
 
         /// <summary>
+        ///     Boss Requirement for Liturgy of the Bell, to only check for raidwides
+        ///     in boss fights, or not.<br />
+        ///     Raidwides check controlled by
+        ///     <see cref="WHM_AoEHeals_LiturgyRaidwideOnly" />.
+        /// </summary>
+        /// <value>
+        ///     <b>Default</b>: <see cref="BossRequirement.On" /> <br />
+        ///     <b>Options</b>: <see cref="BossRequirement">BossRequirement Enum</see>
+        /// </value>
+        /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
+        public static readonly UserInt
+            WHM_AoEHeals_LiturgyRaidwideOnlyBoss =
+                new("WHM_AoEHeals_LiturgyRaidwideOnlyBoss", (int) BossRequirement.On);
+
+        /// <summary>
         ///     Content difficulty selector for Liturgy of the Bell.
         /// </summary>
         /// <value>
-        ///     <b>Default</b>: [true, false]
+        ///     <b>Default</b>: <see cref="ContentCheck.BottomHalfContent" /> <br />
+        ///     <b>Options</b>: <see cref="ContentCheck.BottomHalfContent" />
+        ///     and/or <see cref="ContentCheck.TopHalfContent" />
         /// </value>
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
         internal static UserBoolArray WHM_AoEHeals_LiturgyDifficulty =
             new("WHM_AoEHeals_LiturgyDifficulty", [true, false]);
 
         /// <summary>
-        ///     Content difficulty list set for Liturgy of the Bell.
+        ///     Content difficulty list set for Liturgy of the Bell, set by
+        ///     <see cref="WHM_AoEHeals_LiturgyDifficulty" />.
         /// </summary>
         /// <seealso cref="CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell" />
-        internal static readonly ContentCheck.ListSet WHM_AoEHeals_LiturgyDifficultyListSet =
-            ContentCheck.ListSet.Halved;
+        internal static readonly ContentCheck.ListSet
+            WHM_AoEHeals_LiturgyDifficultyListSet =
+                ContentCheck.ListSet.Halved;
 
         /// <summary>
         ///     Only use Asylum vs a Raidwide.

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -220,12 +220,13 @@ internal partial class WHM
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell:
+                    DrawDifficultyMultiChoice(WHM_AoEHeals_LiturgyDifficulty, WHM_AoEHeals_LiturgyDifficultyListSet,
+                        "Select what content difficulties Liturgy of the Bell should be used in:");
+                    ImGui.NewLine();
+
                     DrawAdditionalBoolChoice(WHM_AoEHeals_LiturgyRaidwideOnly,
                         "Only use when a Raidwide is casting",
                         "Will not use Liturgy of the Bell in the rotation unless we detect a Raidwide is casting.");
-                    
-                    DrawDifficultyMultiChoice(WHM_AoEHeals_LiturgyDifficulty, WHM_AoEHeals_LiturgyDifficultyListSet,
-                        "Select what content difficulties Liturgy of the Bell should be used in:");
                     break;
 
                 case CustomComboPreset.WHM_AoEHeals_Asylum:

--- a/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Helper.cs
@@ -41,6 +41,30 @@ internal partial class WHM
                dotRemaining <= Config.WHM_ST_MainCombo_DoT_Threshold;
     }
 
+    internal static bool BellRaidwideCheckPassed
+    {
+        get
+        {
+            if (!IsEnabled(CustomComboPreset.WHM_AoEHeals_LiturgyOfTheBell))
+                return false;
+            
+            // Skip any checks if Raidwide checking is not enabled
+            if (!Config.WHM_AoEHeals_LiturgyRaidwideOnly)
+                return true;
+
+            // Skip Raidwide check if not in a boss fight, and that check is restricted to bosses
+            if (Config.WHM_AoEHeals_LiturgyRaidwideOnlyBoss ==
+                (int)Config.BossRequirement.On &&
+                !InBossEncounter())
+                return true;
+            
+            if (!RaidWideCasting())
+                return false;
+            
+            return true;
+        }
+    }
+
     #region Heal Priority
 
     public static int GetMatchingConfigST(


### PR DESCRIPTION
- [X] Adds an option to Raidwide Checking to only do that check against bosses
  - [X] Moves the Raidwide check logic from `WHM.cs` to a getter property in `_Helper.cs`
- [X] Removes mention of Raidwide Checking from the Bell Preset itself, since it is its own option to control that
- [X] Minor formatting/documentation modifications

For my lightly-requested addition at the end of my review for PunishXIV/WrathCombo#644